### PR TITLE
パッケージの依存関係エラーを修正

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -1,8 +1,7 @@
 // Live2D表示とチャットの基本機能実装
 import * as PIXI from 'pixi.js';
 import { Live2DModel } from 'pixi-live2d-display';
-// Cubism SDKコアのインポート
-import '@cubism/core';
+// @cubism/coreの直接インポートは削除（CDNで読み込むため）
 
 // グローバル変数
 let app; // PIXIアプリケーション

--- a/client/package.json
+++ b/client/package.json
@@ -9,8 +9,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@cubism/core": "^2.0.3",
-    "@cubism/model-json": "^2.0.3",
     "pixi-live2d-display": "^0.4.0",
     "pixi.js": "^6.5.8"
   },


### PR DESCRIPTION
## パッケージの依存関係の修正

### 問題
`npm install`実行時に以下のエラーが発生していました：
```
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/@cubism%2fcore - Not found
npm error 404
npm error 404  '@cubism/core@^2.0.3' is not in this registry.
```

### 修正内容

1. **package.jsonから不要な依存関係を削除**
   - `@cubism/core` と `@cubism/model-json` を削除
   - これらのパッケージはnpmレジストリに存在しないため

2. **CDN依存方式に切り替え**
   - すでにindex.htmlで追加したCDNからのCubism Core読み込みだけを使用
   - main.jsから`@cubism/core`のインポート文を削除

### 使用方法
この修正により、以下のコマンドで正常にインストールができるようになります：

```bash
cd client
npm install
```

すでにPR #2で追加したCDNを通じてCubism Coreを読み込む方法を採用したため、npmパッケージへの依存は不要となりました。