### PR TITLE
AIチャットモデルをGPT-4.1に更新

### DIFF
--- a/server/services/openai.js
+++ b/server/services/openai.js
@@ -59,7 +59,7 @@ export async function createChatCompletion(userMessage, sessionId = 'default') {
     
     // OpenAI APIリクエスト
     const completion = await openai.createChatCompletion({
-      model: 'gpt-3.5-turbo', // または 'gpt-4'
+      model: 'gpt-4o', // GPT-4.1の最新モデル（gpt-4o）を使用
       messages: conversations[sessionId],
       max_tokens: 150,
       temperature: 0.7,

--- a/server/services/openai.js
+++ b/server/services/openai.js
@@ -59,7 +59,7 @@ export async function createChatCompletion(userMessage, sessionId = 'default') {
     
     // OpenAI APIリクエスト
     const completion = await openai.createChatCompletion({
-      model: 'gpt-4o', // GPT-4.1の最新モデル（gpt-4o）を使用
+      model: 'gpt-4.1', // GPT-4.1を使用
       messages: conversations[sessionId],
       max_tokens: 150,
       temperature: 0.7,


### PR DESCRIPTION
## 変更内容
- AIチャット連携部分を改善するため、`gpt-3.5-turbo`から`gpt-4.1`モデルに更新しました。これにより、より高度で自然な対話が実現できます。
- GPT-4.1は2025年4月に発表された最新モデルで、コーディング能力と指示への応答性が大幅に向上しています。

## 変更の詳細
- server/services/openai.js: OpenAI APIリクエストで使用するモデルを`gpt-4.1`に変更

## 注意事項
- GPT-4.1はGPT-3.5-turboよりもAPIコストが高くなるため、.envファイルで設定されたAPIキーの利用量には注意が必要です。
- より高性能なモデルを採用することで、キャラクターの対話応答品質が向上します。