### PR TITLE
チャットのテストモード機能を追加

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -36,6 +36,11 @@
     
     <!-- チャットUI領域 -->
     <div class="chat-container">
+      <!-- テストモード表示バナー -->
+      <div id="test-mode-banner" class="test-mode-banner" style="display: none;">
+        <span>テストモード: OpenAI APIは使用していません</span>
+      </div>
+      
       <div id="chat-log" class="chat-log"></div>
       
       <div class="settings-panel">
@@ -83,6 +88,10 @@
     <button id="lip-sync-test">口パクテスト</button>
     <button id="voicevox-test">VOICEVOXテスト</button>
     <button id="voicevox-speakers">VOICEVOX話者一覧</button>
+    <div class="test-mode-controls">
+      <button id="toggle-test-mode" class="test-mode-button">テストモード切替</button>
+      <span id="test-mode-status" class="test-mode-status">オフ</span>
+    </div>
   </div>
 
   <!-- デバッグ情報表示領域 - 常に表示 -->

--- a/client/style.css
+++ b/client/style.css
@@ -59,6 +59,16 @@ body {
   background-color: #fff;
 }
 
+/* テストモードバナー */
+.test-mode-banner {
+  background-color: #fcf8e3;
+  color: #8a6d3b;
+  text-align: center;
+  padding: 8px;
+  font-size: 14px;
+  border-bottom: 1px solid #faebcc;
+}
+
 /* 設定パネル */
 .settings-panel {
   display: flex;
@@ -157,6 +167,9 @@ body {
   bottom: 20px;
   right: 20px;
   z-index: 100;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
 }
 
 .test-controls button {
@@ -169,12 +182,48 @@ body {
   font-size: 14px;
   box-shadow: 0 2px 5px rgba(0,0,0,0.2);
   transition: all 0.2s;
+  margin-bottom: 10px;
 }
 
 .test-controls button:hover {
   background-color: #f4511e;
   transform: translateY(-2px);
   box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+}
+
+/* テストモード関連 */
+.test-mode-controls {
+  display: flex;
+  align-items: center;
+  background-color: #f8f9fa;
+  padding: 8px 12px;
+  border-radius: 6px;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+  margin-top: 10px;
+}
+
+.test-mode-button {
+  background-color: #4caf50 !important;
+  margin-bottom: 0 !important;
+  margin-right: 10px;
+}
+
+.test-mode-button.active {
+  background-color: #f44336 !important;
+}
+
+.test-mode-status {
+  font-size: 14px;
+  font-weight: bold;
+  padding: 4px 8px;
+  border-radius: 4px;
+  background-color: #f0f0f0;
+  color: #666;
+}
+
+.test-mode-status.enabled {
+  background-color: #ffcdd2;
+  color: #c62828;
 }
 
 /* レスポンシブデザイン */


### PR DESCRIPTION
## 変更内容
- チャット機能のテストモードを追加しました
- テストモード時はOpenAI APIに接続せずに固定応答を返す機能を実装
- テストモードを切り替えるUIを追加

## 詳細
- サーバー側にテストモード切り替え機能と状態取得APIを追加
- テストモード中はOpenAI APIを使用せず、テスト応答を生成
- クライアント側にテストモード切り替えボタンとバナー表示を追加
- テストモードがUIに明示的に表示され、状態が視覚的に分かりやすくなった

## 利点
- API呼び出しのコストを気にせずに機能テストが可能
- シンプルなテストモードで開発効率が向上
- 固定メッセージを使うことで、予測可能なレスポンスでテストが行える

## 使い方
1. 「テストモード切替」ボタンをクリックしてテストモードを有効/無効にする
2. テストモード有効時は画面上部にバナーが表示される
3. テストモード中のチャットはOpenAI APIに接続されず、テスト用の固定応答のみ返される
4. 音声合成とリップシンクはそのまま機能する