### PR TITLE
虹色まおの口が動かない問題を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,37 @@ npm run dev
 npm run dev
 ```
 
+## Live2Dモデルについて
+
+### モデルのリップシンクパラメータ
+
+Live2Dモデルのリップシンク（口パク）機能を使用するには、モデルが適切なパラメータを持っている必要があります。このプロジェクトでは、以下のようなパラメータ名を自動的に検出して口の動きに使用します：
+
+- 一般的なLive2Dパラメータ
+  - `ParamMouthOpenY`
+  - `PARAM_MOUTH_OPEN_Y`
+  - `ParamMouthOpen`
+  - `PARAM_MOUTH_OPEN`
+
+- 虹色まおモデル用パラメータ
+  - `ParamA` (虹色まおのmodel3.jsonでLipSyncグループに指定されているパラメータ)
+
+モデルによって使用されるパラメータが異なる場合は、`client/main.js`の以下の部分を修正してください：
+
+```javascript
+// 口の開閉値を複数のパラメータに適用する関数
+function applyMouthOpenValue(value) {
+  // ...
+  const mouthParams = [
+    'ParamA',             // 虹色まおの口パクパラメータ
+    'ParamMouthOpenY',
+    'PARAM_MOUTH_OPEN_Y',
+    // 必要に応じて他のパラメータを追加
+  ];
+  // ...
+}
+```
+
 ## 機能実装ステータス
 
 - [x] プロジェクト構造のセットアップ

--- a/client/main.js
+++ b/client/main.js
@@ -321,12 +321,13 @@ function testMouthMovement() {
   
   // 口パク用のパラメータ候補
   const mouthParams = [
-    'ParamMouthOpenY',        // 一般的な口開きパラメータ
-    'PARAM_MOUTH_OPEN_Y',     // 別の形式
-    'ParamMouthOpen',         // 別の命名規則
+    'ParamA',               // 虹色まおの口パクパラメータ
+    'ParamMouthOpenY',      // 一般的な口開きパラメータ
+    'PARAM_MOUTH_OPEN_Y',   // 別の形式
+    'ParamMouthOpen',       // 別の命名規則
     'PARAM_MOUTH_OPEN',
     'Param_mouth_open_y',
-    'ParamMouthForm',         // 口の形状
+    'ParamMouthForm',       // 口の形状
     'PARAM_MOUTH_FORM'
   ];
   
@@ -553,6 +554,7 @@ function performDummyLipSync() {
   
   // 口パク用パラメータ
   const mouthParams = [
+    'ParamA',             // 虹色まおの口パクパラメータ
     'ParamMouthOpenY',
     'PARAM_MOUTH_OPEN_Y',
     'ParamMouthOpen',
@@ -612,6 +614,7 @@ function applyMouthOpenValue(value) {
   
   // パラメータ候補リスト
   const mouthParams = [
+    'ParamA',             // 虹色まおの口パクパラメータ
     'ParamMouthOpenY',
     'PARAM_MOUTH_OPEN_Y',
     'ParamMouthOpen',


### PR DESCRIPTION
## 変更内容

虹色まおの口が動かない問題を修正しました。

### 問題点

モデルの設定ファイル（mao_pro.model3.json）では、リップシンク（LipSync）用のパラメータとして「ParamA」が設定されていますが、コード内の口の動きを制御する関数ではこのパラメータが参照されていませんでした。

### 修正点

1. 以下の3箇所に「ParamA」パラメータを追加
   - `testMouthMovement()`関数内の`mouthParams`配列
   - `performDummyLipSync()`関数内の`mouthParams`配列
   - `applyMouthOpenValue()`関数内の`mouthParams`配列

2. READMEにLive2Dモデルのリップシンクパラメータに関する情報を追加
   - モデルによるパラメータの違い
   - 虹色まおモデル専用のパラメータについて

これにより、`ParamA`パラメータが認識されるようになり、虹色まおの口が正しく動くようになります。